### PR TITLE
[FEAT] 엑세스 토큰 로컬 스토리지에 저장하지 않고 AuthGuard 만들어 새로고침 시에 서버로 재발급 요청 보내도록 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,29 +14,32 @@ import { SignupVerifyPage } from './pages/SignupVerifyPage.tsx';
 import { SignupFormPage } from './pages/SignupFormPage.tsx';
 import { EmailVerifyGuard } from './components/routes/EmailVerifyGuard.tsx';
 import { EmailVerifyContextProvider } from './components/contexts/EmailVerifyContextProvider.tsx';
+import { AuthGuard } from './components/routes/AuthGuard.tsx';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route element={<DefaultLayout />}>
-          <Route element={<EmailVerifyContextProvider />}>
-            <Route path="/" element={<LoginPage />} />
-            <Route element={<EmailVerifyGuard guardType="verifyEmail" />}>
-              <Route path="/signup/verify" element={<SignupVerifyPage />} />
+          <Route element={<AuthGuard />}>
+            <Route element={<EmailVerifyContextProvider />}>
+              <Route path="/" element={<LoginPage />} />
+              <Route element={<EmailVerifyGuard guardType="verifyEmail" />}>
+                <Route path="/signup/verify" element={<SignupVerifyPage />} />
+              </Route>
+              <Route element={<EmailVerifyGuard guardType="requireVerified" />}>
+                <Route path="/signup/form" element={<SignupFormPage />} />
+              </Route>
             </Route>
-            <Route element={<EmailVerifyGuard guardType="requireVerified" />}>
-              <Route path="/signup/form" element={<SignupFormPage />} />
-            </Route>
+
+            <Route path="/oauth/callback/kakao" element={<KakaoRedirectPage />} />
+            <Route path="/oauth2/code/google" element={<GoogleRedirectPage />} />
+            <Route path="/oauth/callback/apple" element={<AppleRedirectPage />} />
+
+            <Route path="/oauth/signup/form" element={<OauthSignupFormPage />} />
+
+            <Route path="/community" element={<CommunityPage />} />
           </Route>
-
-          <Route path="/oauth/callback/kakao" element={<KakaoRedirectPage />} />
-          <Route path="/oauth2/code/google" element={<GoogleRedirectPage />} />
-          <Route path="/oauth/callback/apple" element={<AppleRedirectPage />} />
-
-          <Route path="/oauth/signup/form" element={<OauthSignupFormPage />} />
-
-          <Route path="/community" element={<CommunityPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/routes/AuthGuard.tsx
+++ b/src/components/routes/AuthGuard.tsx
@@ -1,0 +1,52 @@
+import { authClient } from '@/api/axiosConfig';
+import { authService } from '@/services';
+import { useEffect, useState } from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+const PUBLIC_PATHS = [
+  '/',
+  '/signup/verify',
+  '/signup/form',
+  '/oauth/callback/kakao',
+  '/oauth2/code/google',
+  '/oauth/callback/apple',
+  '/oauth/signup/form',
+];
+
+export function AuthGuard() {
+  const location = useLocation();
+  const { pathname } = location;
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+
+  useEffect(() => {
+    const accessToken = authClient.defaults.headers.common['Authorization'];
+    setIsAuthenticated(!!accessToken);
+  }, [pathname]);
+
+  useEffect(() => {
+    const refreshToken = async () => {
+      try {
+        if (!authClient.defaults.headers.common['Authorization']) {
+          const { accessToken } = await authService.refreshAccessToken();
+          authClient.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+          setIsAuthenticated(true);
+        }
+      } catch (error) {
+        console.error('토큰 갱신 실패:', error);
+        setIsAuthenticated(false);
+      }
+    };
+
+    refreshToken();
+  }, []);
+
+  if (PUBLIC_PATHS.includes(pathname) && isAuthenticated) {
+    return <Navigate to={'/community'} />;
+  }
+
+  if (!PUBLIC_PATHS.includes(pathname) && !isAuthenticated) {
+    return <Navigate to={'/'} />;
+  }
+
+  return <Outlet />;
+}

--- a/src/components/routes/index.ts
+++ b/src/components/routes/index.ts
@@ -1,1 +1,2 @@
 export * from './EmailVerifyGuard';
+export * from './AuthGuard';

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,3 +1,4 @@
+import { authClient } from '@/api/axiosConfig';
 import { authService } from '@/services/authService';
 import { LoginFormData } from '@/types';
 import { useState } from 'react';
@@ -7,8 +8,7 @@ export const useLogin = () => {
   const [isCheckedRemember, setIsCheckRemember] = useState<boolean>(!!localStorage.getItem('kBuddyId'));
   const [isLoading, setIsLoading] = useState(false);
 
-  const updateLocalStorage = (token: string, emailOrUserId: string) => {
-    localStorage.setItem('kBuddyAccessToken', token);
+  const updateLocalStorage = (emailOrUserId: string) => {
     if (isCheckedRemember) {
       localStorage.setItem('kBuddyId', emailOrUserId);
     } else {
@@ -21,7 +21,8 @@ export const useLogin = () => {
     try {
       const result = await authService.login(data);
       const { accessToken } = result.data;
-      updateLocalStorage(accessToken, data.emailOrUserId);
+      authClient.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+      updateLocalStorage(data.emailOrUserId);
       setError({ emailOrUserId: '', password: '' });
       return result;
     } catch (error: any) {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/api/axiosConfig';
+import { apiClient, authClient } from '@/api/axiosConfig';
 import { OauthRequest } from '@/types';
 
 export interface LoginRequest {
@@ -70,6 +70,10 @@ export const authService = {
   },
   oauthLogin: async (data: OauthRequest) => {
     const response = await apiClient.post('/auth/oauth/login', data);
+    return response.data;
+  },
+  refreshAccessToken: async () => {
+    const response = await authClient.post('토큰 리프래쉬 주소', {});
     return response.data;
   },
 };


### PR DESCRIPTION
## 작업 사항

- 엑세스 토큰 로컬 스토리지에 저장하지 않고 AuthGuard 만들어 새로고침 시에 서버로 재발급 요청 보내도록 수정