### PR TITLE
[FIX] 앱에서 게시글 작성 완료 페이지에서 이미지 겹침 이슈 해결

### DIFF
--- a/src/components/community/post/Images.tsx
+++ b/src/components/community/post/Images.tsx
@@ -87,20 +87,19 @@ export const Images = () => {
   };
 
   useEffect(() => {
-    let urlsToCleanup: string[] = [];
-
     if (images && !window.ReactNativeWebView) {
       const urls = images.map((file) => URL.createObjectURL(file));
-      urlsToCleanup = urls;
       setImageUrls(urls);
     }
 
     return () => {
-      urlsToCleanup.forEach((url) => {
+      imageUrls.forEach((url) => {
         if (url.startsWith('blob:')) {
           URL.revokeObjectURL(url);
         }
       });
+
+      setImageUrls([]);
     };
   }, [images]);
 


### PR DESCRIPTION
## 작업 사항

- 앱에서 게시글 작성 완료 페이지에서 이미지 겹침 이슈 해결
